### PR TITLE
refactor(package name): fix android package name to lowercase

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
             "supportsTablet": true
         },
         "android": {
-            "package": "com.Clother.Clother",
+            "package": "com.clother.clother",
             "adaptiveIcon": {
                 "foregroundImage": "./assets/adaptive-icon.png",
                 "backgroundColor": "#FFF"


### PR DESCRIPTION
to avoid conflict with the names of classes or interfaces